### PR TITLE
Frontend: split BACKEND_URL env variable into two

### DIFF
--- a/apps/frontend/.env
+++ b/apps/frontend/.env
@@ -1,8 +1,10 @@
 # Server-side environment variables
 ## General
 APP_ENV=${NODE_ENV}
+BACKEND_URL=https://localhost:8090/api/v1
+
 ## TLS
 # NODE_TLS_REJECT_UNAUTHORIZED="0"  # uncomment this for allowing self-signed certificates, cf https://stackoverflow.com/questions/50958516/javascript-self-signed-certificate-error-during-api-call
 
 # Client-side environment variables
-# NEXT_PUBLIC_BACKEND_URL=
+NEXT_PUBLIC_BACKEND_URL=https://localhost:8090/api/v1

--- a/apps/frontend/src/components/hooks/useNewTransactionSubmitHandler.tsx
+++ b/apps/frontend/src/components/hooks/useNewTransactionSubmitHandler.tsx
@@ -2,7 +2,7 @@ import { Transaction, createTransaction } from 'domain-model'
 import { NextRouter, useRouter } from 'next/router'
 import { type SubmitHandler } from 'react-hook-form'
 
-import { BACKEND_BASE_URL } from '../../helpers/constants'
+import { CLIENT_BACKEND_BASE_URL } from '../../helpers/constants'
 import { PAGES } from '../../helpers/pages'
 import { NewTransactionForm } from '../../helpers/zod-form-schemas'
 import { useToast } from '../../lib/shadcn/use-toast'
@@ -52,13 +52,16 @@ const sendTransaction = async (
     toast: any
 ) => {
     try {
-        const response = await fetch(`${BACKEND_BASE_URL}/transactions`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(transaction),
-        })
+        const response = await fetch(
+            `${CLIENT_BACKEND_BASE_URL}/transactions`,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(transaction),
+            }
+        )
         if (response.status === 201) {
             toast({
                 title: 'A new transaction has been created! You submitted the following values:',

--- a/apps/frontend/src/helpers/constants.ts
+++ b/apps/frontend/src/helpers/constants.ts
@@ -1,1 +1,2 @@
-export const BACKEND_BASE_URL = process.env['NEXT_PUBLIC_BACKEND_URL']
+export const CLIENT_BACKEND_BASE_URL = process.env['NEXT_PUBLIC_BACKEND_URL']
+export const SERVER_BACKEND_BASE_URL = process.env['BACKEND_URL']

--- a/apps/frontend/src/pages/transactions/index.tsx
+++ b/apps/frontend/src/pages/transactions/index.tsx
@@ -2,7 +2,10 @@ import Link from 'next/link'
 import React from 'react'
 
 import { SystemInfo, SystemInfoFooter } from '../../components/SystemInfoFooter'
-import { BACKEND_BASE_URL } from '../../helpers/constants'
+import {
+    CLIENT_BACKEND_BASE_URL,
+    SERVER_BACKEND_BASE_URL,
+} from '../../helpers/constants'
 import { PAGES } from '../../helpers/pages'
 import { Button } from '../../lib/shadcn/Button'
 
@@ -33,11 +36,11 @@ const TransactionsOverview = ({ systemInfo }: TransactionsOverviewProps) => {
 export const getServerSideProps = async () => {
     let backendInfo
     try {
-        const req = await fetch(`${BACKEND_BASE_URL}/system/info`)
+        const req = await fetch(`${SERVER_BACKEND_BASE_URL}/system/info`)
         backendInfo = await req.json()
     } catch (err) {
         backendInfo = {
-            error: `Fetch ${BACKEND_BASE_URL} failed`,
+            error: `Fetch ${SERVER_BACKEND_BASE_URL} failed`,
         }
         console.error(err)
     }

--- a/apps/frontend/src/pages/transactions/new.tsx
+++ b/apps/frontend/src/pages/transactions/new.tsx
@@ -14,7 +14,7 @@ import Select from '../../components/Select'
 import TagsManager from '../../components/TagsManager'
 import useNewTransactionForm from '../../components/hooks/useNewTransactionForm'
 import useNewTransactionSubmitHandler from '../../components/hooks/useNewTransactionSubmitHandler'
-import { BACKEND_BASE_URL } from '../../helpers/constants'
+import { SERVER_BACKEND_BASE_URL } from '../../helpers/constants'
 import { Button } from '../../lib/shadcn/Button'
 import { Form } from '../../lib/shadcn/Form'
 
@@ -192,7 +192,7 @@ const NewTransactionPage = ({
 export async function getServerSideProps() {
     try {
         const response = await fetch(
-            `${BACKEND_BASE_URL}/utils/constants/transactions`
+            `${SERVER_BACKEND_BASE_URL}/utils/constants/transactions`
         )
 
         const constants = await response.json()


### PR DESCRIPTION
This is done so that server-side Next.js code can access a different endpoint than the client-side Next.js code