### PR TITLE
Backend: remove https server, run http only

### DIFF
--- a/apps/backend/.env
+++ b/apps/backend/.env
@@ -8,10 +8,6 @@ LOG_LEVEL=info
 # APIKEY=
 # DISABLE_AUTH=false
 
-# SSL/TLS
-# TLS_KEY=
-# TLS_CERT=
-
 # DB
 # PGHOST=
 # PGPORT=

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,8 +1,7 @@
-import https from 'https'
 import { getLogger } from 'logger'
 
-import { createSecureServer } from './server'
 import { RepositoryLocator } from './db/repositoryLocator'
+import { createServer } from './server'
 
 const logger = getLogger('backend')
 
@@ -15,7 +14,7 @@ if (!PORT || !API_BASE_URL) {
     process.exit(1)
 }
 
-createSecureServer()
+createServer()
     .then((server) => {
         server.listen(PORT, () => {
             logger.info(
@@ -23,19 +22,16 @@ createSecureServer()
             )
         })
 
-        handleSignal(server, 'SIGINT')
-        handleSignal(server, 'SIGTERM')
+        handleSignal('SIGINT')
+        handleSignal('SIGTERM')
     })
     .catch((err) => {
         logger.fatal(err)
     })
 
-const handleSignal = (server: https.Server, signal: string) => {
+const handleSignal = (signal: string) => {
     process.on(signal, async () => {
         logger.info(`Signal ${signal} received. Will terminate.`)
-        server.close(() => {
-            logger.info('HTTPS server closed.')
-        })
         await RepositoryLocator.closeRepository()
         logger.info('Database connection closed.')
         process.exit(0)

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -1,10 +1,7 @@
 import { json, urlencoded } from 'body-parser'
 import cors from 'cors'
 import express, { type Express } from 'express'
-import { readFileSync } from 'fs'
-import https from 'https'
 import morgan from 'morgan'
-import path from 'path'
 
 import { backendHttpLogger, checkAuthHeader } from './helpers/middleware'
 import mountRoutes from './routes'
@@ -25,22 +22,4 @@ export const createServer = async (): Promise<Express> => {
     mountRoutes(app)
 
     return app
-}
-
-export const createSecureServer = async (): Promise<https.Server> => {
-    const app = await createServer()
-
-    return https.createServer(
-        {
-            key: readFileSync(
-                process.env['TLS_KEY'] ||
-                path.join(__dirname, 'cert', 'key.pem')
-            ),
-            cert: readFileSync(
-                process.env['TLS_CERT'] ||
-                path.join(__dirname, 'cert', 'cert.pem')
-            ),
-        },
-        app
-    )
 }

--- a/apps/frontend/.env
+++ b/apps/frontend/.env
@@ -2,12 +2,9 @@
 ## General
 APP_ENV=${NODE_ENV}
 
-BACKEND_HOST=https://localhost:8070
+BACKEND_HOST=http://localhost:8070
 BACKEND_API_BASE=/api/v1
 BACKEND_API_KEY=changeit
 
-## TLS
-# NODE_TLS_REJECT_UNAUTHORIZED="0"  # uncomment this for allowing self-signed certificates, cf https://stackoverflow.com/questions/50958516/javascript-self-signed-certificate-error-during-api-call
-
 # Client-side environment variables
-CLIENT_BACKEND_HOST=https://localhost:8070
+CLIENT_BACKEND_HOST=http://localhost:8070


### PR DESCRIPTION
The backend will be deployed in a demilitarized zone (i.e. behind a reverse proxy handling TLS) anyways. Removing the secure server simplifies the setup within the demilitarized zone